### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -1,0 +1,43 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.32.4'
+          channel: 'stable'
+
+      - run: flutter pub get
+      - run: flutter build web --release --base-href "/kanjinomori/"
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: build/web
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/deploy-pages@v4
+        id: deployment


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to automatically build and deploy Flutter web app to GitHub Pages
- Triggers on push to main branch or manual dispatch
- Uses Flutter 3.32.4 stable

## Setup after merge
1. Go to **Settings > Pages**
2. Under "Build and deployment", select **GitHub Actions** as the source

Site will be available at: https://leohoo.github.io/kanjinomori/

🤖 Generated with [Claude Code](https://claude.com/claude-code)