### PR TITLE
Optimize stroke data: 60MB → 4MB (93% reduction)

### DIFF
--- a/.dev/docs/stroke-data-optimization.md
+++ b/.dev/docs/stroke-data-optimization.md
@@ -1,0 +1,44 @@
+# Stroke Data Optimization
+
+## Problem
+
+The original KanjiVG stroke data contained 6,702 kanji entries, resulting in a **60MB** file. This caused:
+
+- Slow initial web app load times
+- Excessive bandwidth usage
+- Poor user experience on mobile/slow connections
+
+## Solution
+
+Filter the stroke data to only include the **1,006 教育漢字** (kyouiku kanji) that the app actually uses.
+
+### Results
+
+| Metric | Before | After | Reduction |
+|--------|--------|-------|-----------|
+| Entries | 6,702 | 1,006 | 85% |
+| File size | 60MB | 4MB | 93% |
+
+## How to Regenerate
+
+If you need to regenerate the filtered stroke data:
+
+```bash
+# Ensure you have the full KanjiVG stroke data first
+# Then run the filter script:
+python3 tool/filter_strokes.py
+```
+
+## Files
+
+- `tool/filter_strokes.py` - Script to filter stroke data
+- `tool/kanjivg_to_json.dart` - Original converter from KanjiVG XML
+- `assets/data/kyouiku_strokes.json` - Filtered stroke data (LFS)
+
+## Future Considerations
+
+If the app expands beyond 教育漢字:
+
+1. **Lazy loading by grade** - Split into `strokes/grade1.json`, etc.
+2. **On-demand loading** - Fetch individual kanji stroke data as needed
+3. **Binary format** - Convert to more compact binary representation

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-assets/data/kanjivg_strokes.json filter=lfs diff=lfs merge=lfs -text
+assets/data/kyouiku_strokes.json filter=lfs diff=lfs merge=lfs -text

--- a/assets/attribution/kanjivg.txt
+++ b/assets/attribution/kanjivg.txt
@@ -1,4 +1,4 @@
 KanjiVG
 Source: https://kanjivg.tagaini.net/
 License: Creative Commons Attribution-ShareAlike 3.0 (CC BY-SA 3.0)
-Note: Stroke data in assets/data/kanjivg_strokes.json is derived from KanjiVG.
+Note: Stroke data in assets/data/kyouiku_strokes.json is derived from KanjiVG.

--- a/assets/data/kanjivg_strokes.json
+++ b/assets/data/kanjivg_strokes.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e8b8cbda2005abb25ef54eb28d9c6fc5199e5fc44bbdf516e87ba6624b1afced
-size 63141532

--- a/assets/data/kyouiku_strokes.json
+++ b/assets/data/kyouiku_strokes.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f894541dd84b924a72d2b6fa321a39364f502773c592dcee28559b8489991a4
+size 4190690

--- a/lib/providers/kanji_provider.dart
+++ b/lib/providers/kanji_provider.dart
@@ -27,7 +27,7 @@ class KanjiRepository {
     if (_strokeTemplates.isNotEmpty) return;
 
     try {
-      final jsonString = await rootBundle.loadString('assets/data/kanjivg_strokes.json');
+      final jsonString = await rootBundle.loadString('assets/data/kyouiku_strokes.json');
       final Map<String, dynamic> decoded = json.decode(jsonString);
       _strokeTemplates = decoded.map((kanji, strokes) {
         final parsedStrokes = (strokes as List)

--- a/tool/filter_strokes.py
+++ b/tool/filter_strokes.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""
+Filter KanjiVG stroke data to only include 教育漢字 (kyouiku kanji).
+
+This reduces the stroke data from ~60MB (6702 entries) to ~9MB (1006 entries),
+significantly improving web app load time.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+def main():
+    # Paths
+    script_dir = Path(__file__).parent
+    project_root = script_dir.parent
+    kanji_json = project_root / "assets" / "data" / "kanji.json"
+    strokes_json = project_root / "assets" / "data" / "kyouiku_strokes.json"
+
+    # Load kyouiku kanji list
+    print("Loading kanji.json...")
+    with open(kanji_json, "r", encoding="utf-8") as f:
+        kanji_list = json.load(f)
+
+    kyouiku_kanji = {k["kanji"] for k in kanji_list}
+    print(f"Found {len(kyouiku_kanji)} 教育漢字")
+
+    # Load stroke data
+    print("Loading kyouiku_strokes.json...")
+    with open(strokes_json, "r", encoding="utf-8") as f:
+        strokes_data = json.load(f)
+
+    print(f"Original stroke data: {len(strokes_data)} entries")
+
+    # Filter to only kyouiku kanji
+    filtered_strokes = {k: v for k, v in strokes_data.items() if k in kyouiku_kanji}
+    print(f"Filtered stroke data: {len(filtered_strokes)} entries")
+
+    # Check for missing kanji
+    missing = kyouiku_kanji - set(filtered_strokes.keys())
+    if missing:
+        print(f"Warning: {len(missing)} kanji missing stroke data: {missing}")
+
+    # Write filtered data
+    print("Writing filtered kyouiku_strokes.json...")
+    with open(strokes_json, "w", encoding="utf-8") as f:
+        json.dump(filtered_strokes, f, ensure_ascii=False, separators=(",", ":"))
+
+    # Report size
+    size_mb = strokes_json.stat().st_size / (1024 * 1024)
+    print(f"New file size: {size_mb:.1f}MB")
+    print("Done!")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Filter stroke data to only include 教育漢字 (1,006 kanji)
- Removes 5,696 unused kanji entries from KanjiVG
- Rename `kanjivg_strokes.json` → `kyouiku_strokes.json` for clarity

## Results

| Metric | Before | After | Reduction |
|--------|--------|-------|-----------|
| Entries | 6,702 | 1,006 | 85% |
| File size | 60MB | 4MB | 93% |
| Gzip size | ~17MB | ~1MB | 94% |

## Changes
- `assets/data/kyouiku_strokes.json` - Renamed & filtered stroke data
- `lib/providers/kanji_provider.dart` - Update loader path
- `.gitattributes` - Update LFS config for new filename
- `tool/filter_strokes.py` - Script for regenerating filtered data
- `.dev/docs/stroke-data-optimization.md` - Documentation

## Test plan
- [ ] Verify web app loads faster
- [ ] Verify stroke grading works for all grades

🤖 Generated with [Claude Code](https://claude.com/claude-code)