### PR TITLE
ci: Add caching to speed up CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           flutter-version: '3.32.4'
           channel: 'stable'
+          cache: true
 
       - run: flutter pub get
       - run: flutter analyze --no-fatal-infos --no-fatal-warnings
@@ -38,6 +39,7 @@ jobs:
         with:
           flutter-version: '3.32.4'
           channel: 'stable'
+          cache: true
 
       - run: flutter pub get
       - run: flutter build web --release
@@ -59,11 +61,13 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
+          cache: 'gradle'
 
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.32.4'
           channel: 'stable'
+          cache: true
 
       - run: flutter pub get
       - run: flutter build apk --release
@@ -85,6 +89,7 @@ jobs:
         with:
           flutter-version: '3.32.4'
           channel: 'stable'
+          cache: true
 
       - run: flutter pub get
       - run: flutter build ipa --no-codesign


### PR DESCRIPTION
## Summary
- Enable Flutter SDK and pub cache caching via `subosito/flutter-action` (`cache: true`) across all 4 jobs
- Add Gradle cache for Android builds via `actions/setup-java` (`cache: 'gradle'`)

## Expected Benefits
- Faster CI runs on cache hits (Flutter SDK ~700MB, pub cache varies)
- Reduced network usage and GitHub Actions minutes

## Test plan
- [ ] CI runs successfully with caching enabled
- [ ] Verify cache hits on subsequent runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)