### PR TITLE
feat: Add movement mode toggle and keyboard support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,10 @@ flutter test
 
 Both must pass before creating a commit.
 
+## Pull Requests
+
+- Prefer squash merge for PRs
+
 ## Project Structure
 
 - `lib/` - Main application code

--- a/lib/games/field/field_screen.dart
+++ b/lib/games/field/field_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flame/game.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../providers/providers.dart';
 import 'field_game.dart';
 
 /// Flutter screen wrapper for the isometric field exploration game.
@@ -16,7 +18,7 @@ import 'field_game.dart';
 /// FieldScreen(key: fieldScreenKey, ...);
 /// // Later: fieldScreenKey.currentState?.onQuestionComplete(doorIndex, true);
 /// ```
-class FieldScreen extends StatefulWidget {
+class FieldScreen extends ConsumerStatefulWidget {
   const FieldScreen({
     super.key,
     required this.stageId,
@@ -42,11 +44,11 @@ class FieldScreen extends StatefulWidget {
   final VoidCallback? onBack;
 
   @override
-  State<FieldScreen> createState() => FieldScreenState();
+  ConsumerState<FieldScreen> createState() => FieldScreenState();
 }
 
 /// Public state class to allow external access via GlobalKey.
-class FieldScreenState extends State<FieldScreen> {
+class FieldScreenState extends ConsumerState<FieldScreen> {
   late FieldGame _game;
 
   @override
@@ -56,9 +58,11 @@ class FieldScreenState extends State<FieldScreen> {
   }
 
   void _initGame() {
+    final player = ref.read(playerProvider);
     _game = FieldGame(
       onDoorEnter: _handleDoorEnter,
       completedDoors: widget.completedDoors,
+      useIsometricMovement: player.useIsometricMovement,
     );
   }
 

--- a/lib/models/kanji.g.dart
+++ b/lib/models/kanji.g.dart
@@ -1,6 +1,10 @@
-// GENERATED CODE - Hive type adapters
+// GENERATED CODE - DO NOT MODIFY BY HAND
 
 part of 'kanji.dart';
+
+// **************************************************************************
+// TypeAdapterGenerator
+// **************************************************************************
 
 class KanjiAdapter extends TypeAdapter<Kanji> {
   @override
@@ -17,7 +21,7 @@ class KanjiAdapter extends TypeAdapter<Kanji> {
       readings: (fields[1] as List).cast<String>(),
       meaning: fields[2] as String,
       grade: fields[3] as int,
-      strokeCount: fields[4] as int? ?? 0,
+      strokeCount: fields[4] as int,
     );
   }
 

--- a/lib/models/player.dart
+++ b/lib/models/player.dart
@@ -31,6 +31,13 @@ class Player extends HiveObject {
   @HiveField(8)
   Map<int, int> stageHighScores; // stageId -> highest coins earned
 
+  @HiveField(9)
+  bool? _useIsometricMovement;
+
+  /// Whether to use isometric movement (default: true for backwards compatibility)
+  bool get useIsometricMovement => _useIsometricMovement ?? true;
+  set useIsometricMovement(bool value) => _useIsometricMovement = value;
+
   Player({
     this.coins = 0,
     this.currentStage = 1,
@@ -41,7 +48,9 @@ class Player extends HiveObject {
     List<String>? ownedCostumes,
     List<String>? ownedDecorations,
     Map<int, int>? stageHighScores,
-  })  : unlockedStages = unlockedStages ?? [1],
+    bool useIsometricMovement = true,
+  })  : _useIsometricMovement = useIsometricMovement,
+        unlockedStages = unlockedStages ?? [1],
         ownedWeapons = ownedWeapons ?? ['wooden_staff'],
         ownedCostumes = ownedCostumes ?? ['default'],
         ownedDecorations = ownedDecorations ?? [],

--- a/lib/models/player.g.dart
+++ b/lib/models/player.g.dart
@@ -1,6 +1,10 @@
-// GENERATED CODE - Hive type adapters
+// GENERATED CODE - DO NOT MODIFY BY HAND
 
 part of 'player.dart';
+
+// **************************************************************************
+// TypeAdapterGenerator
+// **************************************************************************
 
 class PlayerAdapter extends TypeAdapter<Player> {
   @override
@@ -13,8 +17,8 @@ class PlayerAdapter extends TypeAdapter<Player> {
       for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
     };
     return Player(
-      coins: fields[0] as int? ?? 0,
-      currentStage: fields[1] as int? ?? 1,
+      coins: fields[0] as int,
+      currentStage: fields[1] as int,
       unlockedStages: (fields[2] as List?)?.cast<int>(),
       equippedWeapon: fields[3] as String?,
       equippedCostume: fields[4] as String?,
@@ -22,13 +26,13 @@ class PlayerAdapter extends TypeAdapter<Player> {
       ownedCostumes: (fields[6] as List?)?.cast<String>(),
       ownedDecorations: (fields[7] as List?)?.cast<String>(),
       stageHighScores: (fields[8] as Map?)?.cast<int, int>(),
-    );
+    ).._useIsometricMovement = fields[9] as bool?;
   }
 
   @override
   void write(BinaryWriter writer, Player obj) {
     writer
-      ..writeByte(9)
+      ..writeByte(10)
       ..writeByte(0)
       ..write(obj.coins)
       ..writeByte(1)
@@ -46,7 +50,9 @@ class PlayerAdapter extends TypeAdapter<Player> {
       ..writeByte(7)
       ..write(obj.ownedDecorations)
       ..writeByte(8)
-      ..write(obj.stageHighScores);
+      ..write(obj.stageHighScores)
+      ..writeByte(9)
+      ..write(obj._useIsometricMovement);
   }
 
   @override

--- a/lib/providers/player_provider.dart
+++ b/lib/providers/player_provider.dart
@@ -32,6 +32,7 @@ class PlayerNotifier extends StateNotifier<Player> {
       ownedCostumes: state.ownedCostumes,
       ownedDecorations: state.ownedDecorations,
       stageHighScores: state.stageHighScores,
+      useIsometricMovement: state.useIsometricMovement,
     );
     _saveState();
   }
@@ -68,6 +69,7 @@ class PlayerNotifier extends StateNotifier<Player> {
       ownedCostumes: List.from(state.ownedCostumes),
       ownedDecorations: List.from(state.ownedDecorations),
       stageHighScores: state.stageHighScores,
+      useIsometricMovement: state.useIsometricMovement,
     );
     _saveState();
     return true;
@@ -85,6 +87,7 @@ class PlayerNotifier extends StateNotifier<Player> {
       ownedCostumes: state.ownedCostumes,
       ownedDecorations: state.ownedDecorations,
       stageHighScores: state.stageHighScores,
+      useIsometricMovement: state.useIsometricMovement,
     );
     _saveState();
   }
@@ -101,6 +104,7 @@ class PlayerNotifier extends StateNotifier<Player> {
       ownedCostumes: state.ownedCostumes,
       ownedDecorations: state.ownedDecorations,
       stageHighScores: state.stageHighScores,
+      useIsometricMovement: state.useIsometricMovement,
     );
     _saveState();
   }
@@ -118,6 +122,7 @@ class PlayerNotifier extends StateNotifier<Player> {
       ownedCostumes: state.ownedCostumes,
       ownedDecorations: state.ownedDecorations,
       stageHighScores: state.stageHighScores,
+      useIsometricMovement: state.useIsometricMovement,
     );
     _saveState();
   }
@@ -139,6 +144,23 @@ class PlayerNotifier extends StateNotifier<Player> {
       ownedCostumes: state.ownedCostumes,
       ownedDecorations: state.ownedDecorations,
       stageHighScores: newScores,
+      useIsometricMovement: state.useIsometricMovement,
+    );
+    _saveState();
+  }
+
+  void setUseIsometricMovement(bool value) {
+    state = Player(
+      coins: state.coins,
+      currentStage: state.currentStage,
+      unlockedStages: state.unlockedStages,
+      equippedWeapon: state.equippedWeapon,
+      equippedCostume: state.equippedCostume,
+      ownedWeapons: state.ownedWeapons,
+      ownedCostumes: state.ownedCostumes,
+      ownedDecorations: state.ownedDecorations,
+      stageHighScores: state.stageHighScores,
+      useIsometricMovement: value,
     );
     _saveState();
   }

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -61,6 +61,10 @@ class SettingsScreen extends ConsumerWidget {
                   ),
                   children: [
                     const SizedBox(height: 16),
+                    // Control settings section
+                    _buildSectionHeader('操作設定'),
+                    _buildMovementModeTile(ref),
+                    const SizedBox(height: 8),
                     // App info section
                     _buildSectionHeader('アプリ情報'),
                     _buildVersionTile(),
@@ -85,6 +89,42 @@ class SettingsScreen extends ConsumerWidget {
           color: Colors.white70,
           letterSpacing: 1,
         ),
+      ),
+    );
+  }
+
+  Widget _buildMovementModeTile(WidgetRef ref) {
+    final player = ref.watch(playerProvider);
+    final playerNotifier = ref.read(playerProvider.notifier);
+
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.white.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(AppSizes.borderRadius),
+      ),
+      child: SwitchListTile(
+        secondary: const Icon(
+          Icons.gamepad_outlined,
+          color: Colors.white70,
+        ),
+        title: const Text(
+          '移動モード',
+          style: TextStyle(
+            color: Colors.white,
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+        subtitle: Text(
+          player.useIsometricMovement ? 'アイソメトリック' : 'カーディナル',
+          style: const TextStyle(
+            color: Colors.white70,
+            fontSize: 12,
+          ),
+        ),
+        value: player.useIsometricMovement,
+        onChanged: (value) => playerNotifier.setUseIsometricMovement(value),
+        activeTrackColor: AppColors.accent.withValues(alpha: 0.5),
+        thumbColor: WidgetStatePropertyAll(AppColors.accent),
       ),
     );
   }

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -108,14 +108,16 @@ class SettingsScreen extends ConsumerWidget {
           color: Colors.white70,
         ),
         title: const Text(
-          '移動モード',
+          'アイソメトリック移動',
           style: TextStyle(
             color: Colors.white,
             fontWeight: FontWeight.w500,
           ),
         ),
         subtitle: Text(
-          player.useIsometricMovement ? 'アイソメトリック' : 'カーディナル',
+          player.useIsometricMovement
+              ? '斜め方向に移動します'
+              : '上下左右に移動します',
           style: const TextStyle(
             color: Colors.white70,
             fontSize: 12,


### PR DESCRIPTION
## Summary
- Add movement mode setting to toggle between isometric and cardinal movement in Field Game
- Add keyboard support for both Field and Battle games (WASD + Arrow keys for movement, Space/J/K for actions)
- Add settings UI toggle in Settings screen under "操作設定" (Control Settings) section

## Changes
- `lib/models/player.dart` - Add `useIsometricMovement` field with Hive persistence
- `lib/providers/player_provider.dart` - Add setter method for movement mode
- `lib/screens/settings_screen.dart` - Add toggle UI for movement mode
- `lib/games/field/field_game.dart` - Add KeyboardEvents mixin and combine keyboard/joystick input
- `lib/games/field/components/player_component.dart` - Conditional isometric/cardinal movement logic
- `lib/games/battle/battle_game.dart` - Add keyboard support with action keys (Space, J, K)

## Keyboard Mapping
| Key | Field Game | Battle Game |
|-----|------------|-------------|
| W / ↑ | Move up | - |
| S / ↓ | Move down | - |
| A / ← | Move left | Move left |
| D / → | Move right | Move right |
| Space | - | Jump (hold for high jump) |
| J | - | Attack |
| K | - | Shield (hold) |

## Test plan
- [ ] Verify movement mode toggle appears in Settings screen
- [ ] Verify isometric mode (default) works as before in Field game
- [ ] Verify cardinal mode moves in screen directions in Field game
- [ ] Verify keyboard controls work in Field game (WASD + Arrows)
- [ ] Verify keyboard controls work in Battle game (WASD + Arrows for movement)
- [ ] Verify Space/J/K keys work for jump/attack/shield in Battle game
- [ ] Verify setting persists across app restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)